### PR TITLE
Fix external links opening behavior and security

### DIFF
--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -11,12 +11,16 @@ import {
 } from '@/components/SocialIcons'
 import portraitImage from '@/images/portrait.jpg'
 
-function SocialLink({ className, href, children, icon: Icon }) {
+function SocialLink({ className, href, children, icon: Icon, ...props }) {
+  if (props.target === '_blank' && !props.rel) {
+    props.rel = 'noopener noreferrer'
+  }
   return (
     <li className={clsx(className, 'flex')}>
       <Link
         href={href}
         className="group flex text-sm font-medium text-zinc-800 transition hover:text-teal-500 dark:text-zinc-200 dark:hover:text-teal-500"
+        {...props}
       >
         <Icon className="h-6 w-6 flex-none fill-zinc-500 transition group-hover:fill-teal-500" />
         <span className="ml-4">{children}</span>

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -100,6 +100,9 @@ function Article({ article }) {
 }
 
 function SocialLink({ icon: Icon, ...props }) {
+  if (props.target === '_blank' && !props.rel) {
+    props.rel = 'noopener noreferrer'
+  }
   return (
     <Link className="group -m-1 p-1" {...props}>
       <Icon className="h-6 w-6 fill-zinc-500 transition group-hover:fill-zinc-600 dark:fill-zinc-400 dark:group-hover:fill-zinc-300" />

--- a/src/components/Author.jsx
+++ b/src/components/Author.jsx
@@ -47,6 +47,7 @@ export function Author() {
               <Link
                 href="https://www.x.com/mike_mitrakos"
                 target="_blank"
+                rel="noopener noreferrer"
                 className="inline-flex items-center text-base font-medium tracking-tight text-zinc-900"
               >
                 <XIcon className="h-10 w-10 fill-current" />

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -15,6 +15,10 @@ export function Button({ variant = 'primary', className, ...props }) {
     className,
   )
 
+  if (props.target === '_blank' && !props.rel) {
+    props.rel = 'noopener noreferrer'
+  }
+
   return typeof props.href === 'undefined' ? (
     <button className={className} {...props} />
   ) : (

--- a/src/components/Pricing.jsx
+++ b/src/components/Pricing.jsx
@@ -6,7 +6,7 @@ import { Container } from '@/components/Container'
 import { GridPattern } from '@/components/GridPattern'
 import { SectionHeading } from '@/components/SectionHeading'
 
-function Plan({ name, description, price, features, href, featured = false }) {
+function Plan({ name, description, price, features, href, target, featured = false }) {
   return (
     <div
       className={clsx(
@@ -79,6 +79,7 @@ function Plan({ name, description, price, features, href, featured = false }) {
         </div>
         <Button
           href={href}
+          target={target}
           color={featured ? 'white' : 'slate'}
           className="mt-8"
           aria-label={`Get started with the ${name} plan for $${price}`}


### PR DESCRIPTION
## Summary
- ensure target="_blank" links get `rel="noopener noreferrer"`
- forward `target` props in SocialLink and Pricing Plan components
- use rel="noopener noreferrer" on direct external Link in Author section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompted for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689eeeaa053c83319f7653c07613f78a