### PR TITLE
fix: correct MDX syntax for mastering react article

### DIFF
--- a/src/app/articles/mastering-react/page.mdx
+++ b/src/app/articles/mastering-react/page.mdx
@@ -1,4 +1,5 @@
 import { ArticleLayout } from '@/components/ArticleLayout'
+import Image from 'next/image'
 import reactImage from './react.png'
 
 export const article = {
@@ -68,91 +69,93 @@ A simple React app typically has:
 
 Example `HelloWorld.jsx`:
 
-\`\`\`jsx
+```jsx
 export default function HelloWorld() {
-return <h1>Hello, World!</h1>;
+  return <h1>Hello, World!</h1>;
 }
-\`\`\`
+```
 
 4. Using the Component in `App.jsx`:
 
-\`\`\`jsx
+```jsx
 import HelloWorld from './components/HelloWorld';
 
 function App() {
-return (
-
-<div>
-  <HelloWorld />
-</div>
-); }
+  return (
+    <div>
+      <HelloWorld />
+    </div>
+  );
+}
 
 export default App;
-\`\`\`
+```
 
 ## Examples of Using React
 
 1. **State Management with useState**
 
-\`\`\`jsx
+```jsx
 import { useState } from 'react';
 
 function Counter() {
-const [count, setCount] = useState(0);
+  const [count, setCount] = useState(0);
 
-return (
-
-<div>
-  <p>Count: {count}</p>
-  <button onClick={() => setCount(count + 1)}>Increase</button>
-</div>
-); } \`\`\`
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount(count + 1)}>Increase</button>
+    </div>
+  );
+}
+```
 
 This example demonstrates React’s state management in a simple counter app.
 
 2. **Fetching Data with useEffect**
 
-\`\`\`jsx
+```jsx
 import { useEffect, useState } from 'react';
 
 function UsersList() {
-const [users, setUsers] = useState([]);
+  const [users, setUsers] = useState([]);
 
-useEffect(() => {
-fetch('https://jsonplaceholder.typicode.com/users')
-.then((res) => res.json())
-.then((data) => setUsers(data));
-}, []);
+  useEffect(() => {
+    fetch('https://jsonplaceholder.typicode.com/users')
+      .then((res) => res.json())
+      .then((data) => setUsers(data));
+  }, []);
 
-return (
-
-<ul>
-  {users.map((user) => (
-    <li key={user.id}>{user.name}</li>
-  ))}
-</ul>
-); } \`\`\`
+  return (
+    <ul>
+      {users.map((user) => (
+        <li key={user.id}>{user.name}</li>
+      ))}
+    </ul>
+  );
+}
+```
 
 This fetches user data from an API when the component mounts.
 
 3. **Reusable Card Component**
 
-\`\`\`jsx
+```jsx
 function Card({ title, description }) {
-return (
-
-<div className="rounded-md border p-4 shadow-md">
-  <h2 className="text-lg font-bold">{title}</h2>
-  <p>{description}</p>
-</div>
-); } \`\`\`
+  return (
+    <div className="rounded-md border p-4 shadow-md">
+      <h2 className="text-lg font-bold">{title}</h2>
+      <p>{description}</p>
+    </div>
+  );
+}
+```
 
 Use it like this:
 
-\`\`\`jsx
-
+```jsx
 <Card title="React Rocks" description="Learn React to build awesome UIs." />
-\`\`\`
+```
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary
- import missing `Image` component
- replace escaped code fences with proper fenced blocks in `mastering-react` article

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Interactive ESLint configuration prompt)*
- `npm run build` *(fails: Missing NEXT_PUBLIC_SITE_URL environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689efc09c5d08331a88ef4b9ca098367