### PR TITLE
Improve SEO and GEO metadata coverage

### DIFF
--- a/src/app/articles/mastering-react/page.mdx
+++ b/src/app/articles/mastering-react/page.mdx
@@ -7,13 +7,29 @@ export const article = {
   date: '2025-08-13',
   title:
     'Mastering React: Key Concepts, Best Practices, and How to Build Efficient Applications',
+  url: `https://www.mitrakos.com/articles/mastering-react`,
   description:
     'Learn the core principles of React, its advantages for building scalable UIs, and practical tips to structure, optimize, and maintain your applications effectively.',
 }
 
+
 export const metadata = {
   title: article.title,
   description: article.description,
+  alternates: {
+    canonical: '/articles/mastering-react',
+  },
+  openGraph: {
+    type: 'article',
+    title: article.title,
+    description: article.description,
+    url: `https://www.mitrakos.com/articles/mastering-react`,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: article.title,
+    description: article.description,
+  },
 }
 
 export default (props) => <ArticleLayout article={article} {...props} />

--- a/src/app/articles/mastering-tailwind-css/page.mdx
+++ b/src/app/articles/mastering-tailwind-css/page.mdx
@@ -6,13 +6,29 @@ export const article = {
   date: '2024-12-12',
   title:
     'Mastering Tailwind CSS: Why It’s a Game-Changer and How to Use It Effectively',
+  url: `https://www.mitrakos.com/articles/mastering-tailwind-css`,
   description:
     'Discover why Tailwind CSS is a powerful utility-first framework for modern web design. Learn its benefits, setup process, and practical examples to streamline your workflow.',
 }
 
+
 export const metadata = {
   title: article.title,
   description: article.description,
+  alternates: {
+    canonical: '/articles/mastering-tailwind-css',
+  },
+  openGraph: {
+    type: 'article',
+    title: article.title,
+    description: article.description,
+    url: `https://www.mitrakos.com/articles/mastering-tailwind-css`,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: article.title,
+    description: article.description,
+  },
 }
 
 export default (props) => <ArticleLayout article={article} {...props} />

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -4,7 +4,11 @@ import Script from 'next/script'
 
 import '@/styles/tailwind.css'
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.mitrakos.com'
+const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID
+
 export const metadata = {
+  metadataBase: new URL(siteUrl),
   title: {
     template: '%s - Michael Mitrakos',
     default:
@@ -12,34 +16,108 @@ export const metadata = {
   },
   description:
     'I’m Michael, a full-stack senior software engineer and tech lead from the US. For the past 10 years I’ve been leading teams to build high-quality web applications.',
+  keywords: [
+    'Michael Mitrakos',
+    'software engineer',
+    'tech lead',
+    'frontend engineering',
+    'web development',
+  ],
+  authors: [{ name: 'Michael Mitrakos', url: siteUrl }],
+  creator: 'Michael Mitrakos',
+  publisher: 'Michael Mitrakos',
   alternates: {
+    canonical: '/',
     types: {
-      'application/rss+xml': `${process.env.NEXT_PUBLIC_SITE_URL}/feed.xml`,
+      'application/rss+xml': `${siteUrl}/feed.xml`,
     },
   },
+  openGraph: {
+    type: 'website',
+    url: siteUrl,
+    title: 'Michael Mitrakos - Software designer, founder, and world traveler',
+    description:
+      'I’m Michael, a full-stack senior software engineer and tech lead from the US. For the past 10 years I’ve been leading teams to build high-quality web applications.',
+    siteName: 'Michael Mitrakos',
+    images: [{ url: '/cover.avif', width: 1200, height: 630, alt: 'Michael Mitrakos' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Michael Mitrakos - Software designer, founder, and world traveler',
+    description:
+      'I’m Michael, a full-stack senior software engineer and tech lead from the US. For the past 10 years I’ve been leading teams to build high-quality web applications.',
+    images: ['/cover.avif'],
+    creator: '@Mike_Mitrakos',
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
+  },
+}
+
+const personSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Michael Mitrakos',
+  jobTitle: 'Senior Software Engineer and Tech Lead',
+  url: siteUrl,
+  sameAs: [
+    'https://x.com/Mike_Mitrakos',
+    'https://www.instagram.com/mike_mitrakos/',
+    'https://github.com/mitrakmt',
+    'https://www.linkedin.com/in/mitrakos',
+  ],
+}
+
+const websiteSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'Michael Mitrakos',
+  url: siteUrl,
+  inLanguage: 'en-US',
 }
 
 export default function RootLayout({ children }) {
   return (
     <html lang="en" className="h-full antialiased" suppressHydrationWarning>
       <body className="flex h-full bg-zinc-50 dark:bg-black">
-      <Script 
-          strategy="afterInteractive"
-          src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}`}
+        {gaMeasurementId && (
+          <>
+            <Script
+              strategy="afterInteractive"
+              src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`}
+            />
+            <Script
+              id="google-analytics"
+              strategy="afterInteractive"
+              dangerouslySetInnerHTML={{
+                __html: `
+                  window.dataLayer = window.dataLayer || [];
+                  function gtag(){dataLayer.push(arguments);}
+                  gtag('js', new Date());
+                  gtag('config', '${gaMeasurementId}');
+                `,
+              }}
+            />
+          </>
+        )}
+        <Script
+          id="person-schema"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
         />
-      <Script 
-          id="google-analytics"
-          strategy="afterInteractive"
-          dangerouslySetInnerHTML={{
-            __html: `
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-              gtag('js', new Date());
-              gtag('config', '${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}');
-            `,
-          }}
+        <Script
+          id="website-schema"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
         />
-        
         <Providers>
           <div className="flex w-full">
             <Layout>{children}</Layout>

--- a/src/app/llms.txt/route.js
+++ b/src/app/llms.txt/route.js
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.mitrakos.com'
+
+const content = `# Michael Mitrakos
+
+> Official website and portfolio for Michael Mitrakos.
+
+## About
+Michael Mitrakos is a US-based senior software engineer and tech lead. The site includes his background, selected projects, technical writing, and contact information.
+
+## Primary sections
+- Homepage: ${siteUrl}/
+- About: ${siteUrl}/about
+- Projects: ${siteUrl}/projects
+- Articles index: ${siteUrl}/articles
+- Technology: ${siteUrl}/technology
+- InitJS: ${siteUrl}/initjs
+- Ebook: ${siteUrl}/ebook
+
+## Feeds and discovery
+- RSS feed: ${siteUrl}/feed.xml
+- XML sitemap: ${siteUrl}/sitemap.xml
+`
+
+export async function GET() {
+  return new NextResponse(content, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  })
+}

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -22,6 +22,17 @@ import image5 from '@/images/photos/image-5.jpg'
 import { getAllArticles } from '@/lib/articles'
 import { formatDate } from '@/lib/formatDate'
 
+
+export const metadata = {
+  title: 'Home',
+  description:
+    'Portfolio of Michael Mitrakos, a US-based senior software engineer and tech lead focused on building high-quality web applications.',
+  alternates: {
+    canonical: '/',
+  },
+}
+
+
 function MailIcon(props) {
   return (
     <svg

--- a/src/app/robots.js
+++ b/src/app/robots.js
@@ -1,0 +1,12 @@
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.mitrakos.com'
+
+export default function robots() {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  }
+}

--- a/src/app/sitemap.xml/route.js
+++ b/src/app/sitemap.xml/route.js
@@ -1,37 +1,54 @@
-// app/sitemap.xml/route.ts
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server'
+
+import { getAllArticles } from '@/lib/articles'
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.mitrakos.com'
 
 export async function GET() {
-  const siteUrl = "https://www.mitrakos.com"; // Replace with your website's URL
-  const staticPages = ["/", "/articles", "/projects", "/technology", "/about", "/initjs", "/ebook"];
-  const dynamicPages = await getDynamicPages();
+  const staticPages = [
+    '/',
+    '/about',
+    '/articles',
+    '/ebook',
+    '/initjs',
+    '/projects',
+    '/technology',
+  ]
 
-  const urls = [...staticPages, ...dynamicPages];
+  const articles = await getAllArticles()
+  const dynamicPages = articles.map((article) => ({
+    path: `/articles/${article.slug}`,
+    lastmod: new Date(article.date).toISOString(),
+    changefreq: 'monthly',
+    priority: '0.8',
+  }))
+
+  const staticEntries = staticPages.map((path) => ({
+    path,
+    lastmod: new Date().toISOString(),
+    changefreq: path === '/' ? 'weekly' : 'monthly',
+    priority: path === '/' ? '1.0' : '0.7',
+  }))
+
+  const urls = [...staticEntries, ...dynamicPages]
 
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  ${urls
-    .map(
-      (url) => `
-    <url>
-      <loc>${siteUrl}${url}</loc>
-      <lastmod>${new Date().toISOString()}</lastmod>
-      <changefreq>daily</changefreq>
-      <priority>${url === "/" ? "1.0" : "0.7"}</priority>
-    </url>
-  `
-    )
-    .join("")}
-</urlset>`;
+${urls
+  .map(
+    ({ path, lastmod, changefreq, priority }) => `  <url>
+    <loc>${siteUrl}${path}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>${changefreq}</changefreq>
+    <priority>${priority}</priority>
+  </url>`
+  )
+  .join('\n')}
+</urlset>`
 
   return new NextResponse(sitemap, {
     headers: {
-      "Content-Type": "application/xml",
+      'Content-Type': 'application/xml',
     },
-  });
-}
-
-async function getDynamicPages() {
-  // Replace this with your logic to fetch dynamic routes (e.g., from a database or API)
-  return ["/articles/mastering-tailwind-css"];
+  })
 }

--- a/src/components/ArticleLayout.jsx
+++ b/src/components/ArticleLayout.jsx
@@ -25,6 +25,20 @@ export function ArticleLayout({ article, children }) {
   let router = useRouter()
   let { previousPathname } = useContext(AppContext)
 
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: article.title,
+    datePublished: article.date,
+    dateModified: article.date,
+    author: {
+      '@type': 'Person',
+      name: article.author,
+    },
+    description: article.description,
+    mainEntityOfPage: article.url,
+  }
+
   return (
     <Container className="mt-16 lg:mt-32">
       <div className="xl:relative">
@@ -40,6 +54,10 @@ export function ArticleLayout({ article, children }) {
             </button>
           )}
           <article>
+            <script
+              type="application/ld+json"
+              dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+            />
             <header className="flex flex-col">
               <h1 className="mt-6 text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">
                 {article.title}


### PR DESCRIPTION
### Motivation

- Provide consistent, machine-readable site and article metadata so search engines and LLM-based discovery (GEO) can better index and surface the site. 
- Improve crawlability and provenance (canonical URLs, sitemap, robots, JSON-LD) without changing UI or page content.

### Description

- Expanded global metadata in `src/app/layout.jsx` with `metadataBase`, `keywords`, `authors`, Open Graph, Twitter card, and `robots` directives, and added `Person` and `WebSite` JSON-LD payloads. 
- Made Google Analytics injection conditional on `NEXT_PUBLIC_GA_MEASUREMENT_ID` in `src/app/layout.jsx` to avoid emitting invalid GA snippets when the env var is unset. 
- Rewrote `src/app/sitemap.xml/route.js` to generate a dynamic sitemap using `getAllArticles()` with per-URL `lastmod`, `changefreq`, and `priority`, and added a `robots` route at `src/app/robots.js` for explicit discovery. 
- Added an LLM-friendly site index at `src/app/llms.txt/route.js`, added homepage metadata in `src/app/page.jsx`, added article-level `url` and metadata (`alternates`, Open Graph, Twitter) in article MDX files, and injected `BlogPosting` JSON-LD from `src/components/ArticleLayout.jsx` for richer article semantics.

### Testing

- Ran `npm run lint`, but the environment prompted for interactive ESLint setup so linting could not complete non-interactively. 
- Ran `npm run build`; compilation succeeded and static pages were generated, but prerendering of `/feed.xml` failed because `NEXT_PUBLIC_SITE_URL` was not provided in the build environment. 
- During build validation an earlier `ReferenceError: articleUrl is not defined` was encountered and then fixed by switching MDX article metadata to stable canonical URLs, after which the build progressed to prerendering before the missing env var halted completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbb6a0456c8331a86113237efdddd6)