### PR TITLE
Add Vercel Analytics to root layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mdx-js/react": "^3.0.0",
     "@next/mdx": "^14.0.4",
     "@tailwindcss/typography": "^0.5.4",
+    "@vercel/analytics": "^1.5.0",
     "autoprefixer": "^10.4.12",
     "cheerio": "^1.0.0-rc.12",
     "clsx": "^2.1.0",

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,6 +1,7 @@
 import { Providers } from '@/app/providers'
 import { Layout } from '@/components/Layout'
 import Script from 'next/script'
+import { Analytics } from '@vercel/analytics/next'
 
 import '@/styles/tailwind.css'
 
@@ -123,6 +124,7 @@ export default function RootLayout({ children }) {
             <Layout>{children}</Layout>
           </div>
         </Providers>
+        <Analytics />
       </body>
     </html>
   )


### PR DESCRIPTION
### Motivation
- Integrate Vercel Analytics site-wide per the requested setup and attached screenshot so page views are tracked with `@vercel/analytics`.

### Description
- Added `@vercel/analytics` to the `dependencies` section of `package.json`.
- Imported `Analytics` from `@vercel/analytics/next` in `src/app/layout.jsx`.
- Rendered `<Analytics />` in `RootLayout` (placed before `</body>`) so analytics run across the entire app.

### Testing
- Attempted `npm i @vercel/analytics`, but the install failed with `403 Forbidden` from the npm registry, so the dependency was added directly to `package.json` instead.
- Ran `npm run lint`, but the process could not complete because Next.js prompted for an interactive ESLint configuration and the prompt was not resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1694c738833197166145b25b5965)