### PR TITLE
Centralize site metadata and refine sitemap/feed/robots handling

### DIFF
--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -10,6 +10,7 @@ import {
   XIcon,
 } from '@/components/SocialIcons'
 import portraitImage from '@/images/portrait.jpg'
+import { pageMetadata } from '@/lib/site'
 
 function SocialLink({ className, href, children, icon: Icon, ...props }) {
   if (props.target === '_blank' && !props.rel) {
@@ -40,11 +41,12 @@ function MailIcon(props) {
   )
 }
 
-export const metadata = {
-  title: 'About',
+export const metadata = pageMetadata({
+  title: 'About Michael Mitrakos',
   description:
-    'I’m Michael Mitrakos, a US-based software engineer who loves frontend engineering and leading teams.',
-}
+    'Learn about Michael Mitrakos, a US-based senior software engineer and tech lead focused on frontend engineering, team leadership, and web product development.',
+  path: '/about',
+})
 
 export default function About() {
   return (

--- a/src/app/articles/mastering-react/page.mdx
+++ b/src/app/articles/mastering-react/page.mdx
@@ -12,7 +12,6 @@ export const article = {
     'Learn the core principles of React, its advantages for building scalable UIs, and practical tips to structure, optimize, and maintain your applications effectively.',
 }
 
-
 export const metadata = {
   title: article.title,
   description: article.description,
@@ -24,11 +23,14 @@ export const metadata = {
     title: article.title,
     description: article.description,
     url: `https://www.mitrakos.com/articles/mastering-react`,
+    publishedTime: article.date,
+    authors: [article.author],
   },
   twitter: {
     card: 'summary_large_image',
     title: article.title,
     description: article.description,
+    creator: '@Mike_Mitrakos',
   },
 }
 

--- a/src/app/articles/mastering-tailwind-css/page.mdx
+++ b/src/app/articles/mastering-tailwind-css/page.mdx
@@ -11,7 +11,6 @@ export const article = {
     'Discover why Tailwind CSS is a powerful utility-first framework for modern web design. Learn its benefits, setup process, and practical examples to streamline your workflow.',
 }
 
-
 export const metadata = {
   title: article.title,
   description: article.description,
@@ -23,11 +22,14 @@ export const metadata = {
     title: article.title,
     description: article.description,
     url: `https://www.mitrakos.com/articles/mastering-tailwind-css`,
+    publishedTime: article.date,
+    authors: [article.author],
   },
   twitter: {
     card: 'summary_large_image',
     title: article.title,
     description: article.description,
+    creator: '@Mike_Mitrakos',
   },
 }
 

--- a/src/app/articles/page.jsx
+++ b/src/app/articles/page.jsx
@@ -2,6 +2,7 @@ import { Card } from '@/components/Card'
 import { SimpleLayout } from '@/components/SimpleLayout'
 import { getAllArticles } from '@/lib/articles'
 import { formatDate } from '@/lib/formatDate'
+import { pageMetadata } from '@/lib/site'
 
 function Article({ article }) {
   return (
@@ -32,11 +33,12 @@ function Article({ article }) {
   )
 }
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: 'Articles',
   description:
-    'All of my long-form thoughts on programming, leadership, product design, and more, collected in chronological order.',
-}
+    'Read Michael Mitrakos’s articles on programming, frontend engineering, leadership, product design, and building high-quality web applications.',
+  path: '/articles',
+})
 
 export default async function ArticlesIndex() {
   let articles = await getAllArticles()

--- a/src/app/ebook/page.jsx
+++ b/src/app/ebook/page.jsx
@@ -11,6 +11,14 @@ import { Testimonial } from '@/components/Testimonial'
 import { Testimonials } from '@/components/Testimonials'
 import avatarImage1 from '@/images/avatars/avatar-1.png'
 import avatarImage2 from '@/images/avatars/avatar-2.png'
+import { pageMetadata } from '@/lib/site'
+
+export const metadata = pageMetadata({
+  title: 'From Zero to Code JavaScript Ebook',
+  description:
+    'Learn JavaScript from the ground up with From Zero to Code, a beginner-friendly ebook by Michael Mitrakos with practical lessons, resources, and examples.',
+  path: '/ebook',
+})
 
 export default function Home() {
   return (
@@ -28,7 +36,9 @@ export default function Home() {
         }}
       >
         <p>
-          “An incredibly clear and approachable guide—From Zero to Code turned JavaScript from a daunting subject into something I now feel excited to learn and explore further!”
+          “An incredibly clear and approachable guide—From Zero to Code turned
+          JavaScript from a daunting subject into something I now feel excited
+          to learn and explore further!”
         </p>
       </Testimonial>
       <Screencasts />
@@ -41,7 +51,9 @@ export default function Home() {
         }}
       >
         <p>
-        "An excellent resource for beginners! From Zero to Code made JavaScript feel approachable and fun—this ebook helped me go from complete beginner to confident coder in no time!"
+          "An excellent resource for beginners! From Zero to Code made
+          JavaScript feel approachable and fun—this ebook helped me go from
+          complete beginner to confident coder in no time!"
         </p>
       </Testimonial>
       <Resources />

--- a/src/app/feed.xml/route.js
+++ b/src/app/feed.xml/route.js
@@ -2,13 +2,9 @@ import assert from 'assert'
 import * as cheerio from 'cheerio'
 import { Feed } from 'feed'
 
+import { siteDescription, siteUrl } from '@/lib/site'
+
 export async function GET(req) {
-  let siteUrl = process.env.NEXT_PUBLIC_SITE_URL
-
-  if (!siteUrl) {
-    throw Error('Missing NEXT_PUBLIC_SITE_URL environment variable')
-  }
-
   let author = {
     name: 'Michael Mitrakos',
     email: 'mike@higglo.io',
@@ -16,7 +12,7 @@ export async function GET(req) {
 
   let feed = new Feed({
     title: author.name,
-    description: 'Your blog description',
+    description: siteDescription,
     author,
     id: siteUrl,
     link: siteUrl,

--- a/src/app/initjs/page.jsx
+++ b/src/app/initjs/page.jsx
@@ -1,16 +1,15 @@
 import { Card } from '@/components/Card'
 import { SimpleLayout } from '@/components/SimpleLayout'
 import { formatDate } from '@/lib/formatDate'
+import { pageMetadata } from '@/lib/site'
 
-import articles from './articles.json';
+import articles from './articles.json'
 
 function Article({ article }) {
   return (
     <article className="md:grid md:grid-cols-4 md:items-baseline">
       <Card className="md:col-span-3">
-        <Card.Title href={article.url}>
-          {article.title}
-        </Card.Title>
+        <Card.Title href={article.url}>{article.title}</Card.Title>
         <Card.Eyebrow
           as="time"
           dateTime={article.date}
@@ -32,11 +31,12 @@ function Article({ article }) {
   )
 }
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: 'initJS | Learn JavaScript',
   description:
-    'Learn about everything Javascript to take you from beginner to advanced.',
-}
+    'Learn JavaScript with initJS articles and resources that take you from beginner concepts to more advanced programming topics.',
+  path: '/initjs',
+})
 
 export default async function ArticlesIndex() {
   return (

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -3,9 +3,10 @@ import { Layout } from '@/components/Layout'
 import Script from 'next/script'
 import { Analytics } from '@vercel/analytics/next'
 
+import { siteDescription, siteName, siteUrl } from '@/lib/site'
+
 import '@/styles/tailwind.css'
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.mitrakos.com'
 const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID
 
 export const metadata = {
@@ -15,8 +16,7 @@ export const metadata = {
     default:
       'Michael Mitrakos - Software designer, founder, and world traveler',
   },
-  description:
-    'I’m Michael, a full-stack senior software engineer and tech lead from the US. For the past 10 years I’ve been leading teams to build high-quality web applications.',
+  description: siteDescription,
   keywords: [
     'Michael Mitrakos',
     'software engineer',
@@ -24,30 +24,29 @@ export const metadata = {
     'frontend engineering',
     'web development',
   ],
-  authors: [{ name: 'Michael Mitrakos', url: siteUrl }],
-  creator: 'Michael Mitrakos',
-  publisher: 'Michael Mitrakos',
+  applicationName: siteName,
+  authors: [{ name: siteName, url: siteUrl }],
+  creator: siteName,
+  publisher: siteName,
   alternates: {
     canonical: '/',
     types: {
       'application/rss+xml': `${siteUrl}/feed.xml`,
+      'text/plain': `${siteUrl}/llms.txt`,
     },
   },
   openGraph: {
     type: 'website',
     url: siteUrl,
     title: 'Michael Mitrakos - Software designer, founder, and world traveler',
-    description:
-      'I’m Michael, a full-stack senior software engineer and tech lead from the US. For the past 10 years I’ve been leading teams to build high-quality web applications.',
-    siteName: 'Michael Mitrakos',
-    images: [{ url: '/cover.avif', width: 1200, height: 630, alt: 'Michael Mitrakos' }],
+    description: siteDescription,
+    siteName,
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Michael Mitrakos - Software designer, founder, and world traveler',
-    description:
-      'I’m Michael, a full-stack senior software engineer and tech lead from the US. For the past 10 years I’ve been leading teams to build high-quality web applications.',
-    images: ['/cover.avif'],
+    description: siteDescription,
     creator: '@Mike_Mitrakos',
   },
   robots: {
@@ -66,7 +65,7 @@ export const metadata = {
 const personSchema = {
   '@context': 'https://schema.org',
   '@type': 'Person',
-  name: 'Michael Mitrakos',
+  name: siteName,
   jobTitle: 'Senior Software Engineer and Tech Lead',
   url: siteUrl,
   sameAs: [
@@ -80,7 +79,7 @@ const personSchema = {
 const websiteSchema = {
   '@context': 'https://schema.org',
   '@type': 'WebSite',
-  name: 'Michael Mitrakos',
+  name: siteName,
   url: siteUrl,
   inLanguage: 'en-US',
 }

--- a/src/app/llms.txt/route.js
+++ b/src/app/llms.txt/route.js
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.mitrakos.com'
+import { siteUrl } from '@/lib/site'
 
 const content = `# Michael Mitrakos
 

--- a/src/app/projects/page.jsx
+++ b/src/app/projects/page.jsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 
 import { Card } from '@/components/Card'
 import { SimpleLayout } from '@/components/SimpleLayout'
+import { pageMetadata } from '@/lib/site'
 import logoHigglo from '@/images/logos/higglo_digital.jpg'
 import logoInitjs from '@/images/logos/initjs.png'
 import logoWanderlust from '@/images/logos/wanderlustapp.jpg'
@@ -10,54 +11,59 @@ import logonomads from '@/images/logos/nomads.png'
 import logoenhl from '@/images/logos/enhl.png'
 import logoOrthodoxChristianity101 from '@/images/logos/oc101.avif'
 
-
 const projects = [
   {
     name: 'Higglo Digital',
-    description:
-      'Memorable brand experiences, SEO & award winning websites',
+    description: 'Memorable brand experiences, SEO & award winning websites',
     link: { href: 'http://www.higglo.io', label: 'higglo.io' },
     logo: logoHigglo,
   },
   {
     name: 'Wanderlust App',
-    description:
-      'Beautiful places on your new tab page',
+    description: 'Beautiful places on your new tab page',
     link: { href: 'https://www.wanderlustapp.io', label: 'wanderlustapp.io' },
     logo: logoWanderlust,
   },
   {
     name: 'Web Design Awards',
-    description:
-      'Recognizing the best of the web.',
-    link: { href: 'https://www.webdesignawards.io', label: 'webdesignawards.io' },
+    description: 'Recognizing the best of the web.',
+    link: {
+      href: 'https://www.webdesignawards.io',
+      label: 'webdesignawards.io',
+    },
     logo: logoWebdesign,
   },
   {
     name: 'Nomads Ice Hockey',
-    description:
-      'The first ice hockey team in Egypt.',
-    link: { href: 'https://www.nomadsicehockey.com', label: 'nomadsicehockey.com' },
+    description: 'The first ice hockey team in Egypt.',
+    link: {
+      href: 'https://www.nomadsicehockey.com',
+      label: 'nomadsicehockey.com',
+    },
     logo: logonomads,
   },
   {
     name: 'ENHL',
     description:
       'The Egyptian National Hockey League, the first ice hockey league in Egypt.',
-    link: { href: 'https://www.egyptianhockeyleague.com', label: 'egyptianhockeyleague.com' },
+    link: {
+      href: 'https://www.egyptianhockeyleague.com',
+      label: 'egyptianhockeyleague.com',
+    },
     logo: logoenhl,
   },
   {
     name: 'Orthodox Christianity 101',
-    description:
-      'Teaching the basics of Orthodox Christianity for beginners',
-    link: { href: 'https://www.orthodoxchristianity101.com', label: 'orthodoxchristianity101.com' },
+    description: 'Teaching the basics of Orthodox Christianity for beginners',
+    link: {
+      href: 'https://www.orthodoxchristianity101.com',
+      label: 'orthodoxchristianity101.com',
+    },
     logo: logoOrthodoxChristianity101,
   },
   {
     name: 'InitJS',
-    description:
-      'Teaching JavaScript to over 400,000 readers..',
+    description: 'Teaching JavaScript to over 400,000 readers..',
     link: { href: 'https://www.initjs.org', label: 'initjs.org' },
     logo: logoInitjs,
   },
@@ -74,10 +80,12 @@ function LinkIcon(props) {
   )
 }
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: 'Projects',
-  description: 'Things I’ve made trying to put my dent in the universe.',
-}
+  description:
+    'Explore selected projects by Michael Mitrakos, including web applications, startup products, and engineering work across frontend and full-stack development.',
+  path: '/projects',
+})
 
 export default function Projects() {
   return (

--- a/src/app/robots.js
+++ b/src/app/robots.js
@@ -1,4 +1,6 @@
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.mitrakos.com'
+import { siteUrl } from '@/lib/site'
+
+const siteHost = new URL(siteUrl).host
 
 export default function robots() {
   return {
@@ -7,6 +9,6 @@ export default function robots() {
       allow: '/',
     },
     sitemap: `${siteUrl}/sitemap.xml`,
-    host: siteUrl,
+    host: siteHost,
   }
 }

--- a/src/app/sitemap.xml/route.js
+++ b/src/app/sitemap.xml/route.js
@@ -1,54 +1,89 @@
 import { NextResponse } from 'next/server'
 
 import { getAllArticles } from '@/lib/articles'
+import { siteUrl } from '@/lib/site'
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.mitrakos.com'
+const staticPages = [
+  {
+    path: '/',
+    changefreq: 'weekly',
+    priority: '1.0',
+  },
+  {
+    path: '/about',
+    changefreq: 'monthly',
+    priority: '0.8',
+  },
+  {
+    path: '/articles',
+    changefreq: 'weekly',
+    priority: '0.8',
+  },
+  {
+    path: '/ebook',
+    changefreq: 'monthly',
+    priority: '0.8',
+  },
+  {
+    path: '/initjs',
+    changefreq: 'weekly',
+    priority: '0.7',
+  },
+  {
+    path: '/projects',
+    changefreq: 'monthly',
+    priority: '0.8',
+  },
+  {
+    path: '/technology',
+    changefreq: 'monthly',
+    priority: '0.6',
+  },
+]
+
+function escapeXml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}
+
+function renderTag(name, value) {
+  if (!value) {
+    return ''
+  }
+
+  return `    <${name}>${escapeXml(value)}</${name}>\n`
+}
+
+function renderUrl({ path, lastmod, changefreq, priority }) {
+  return `  <url>
+    <loc>${escapeXml(new URL(path, siteUrl).toString())}</loc>
+${renderTag('lastmod', lastmod)}${renderTag('changefreq', changefreq)}${renderTag('priority', priority)}  </url>`
+}
 
 export async function GET() {
-  const staticPages = [
-    '/',
-    '/about',
-    '/articles',
-    '/ebook',
-    '/initjs',
-    '/projects',
-    '/technology',
-  ]
-
   const articles = await getAllArticles()
   const dynamicPages = articles.map((article) => ({
     path: `/articles/${article.slug}`,
-    lastmod: new Date(article.date).toISOString(),
+    lastmod: article.date,
     changefreq: 'monthly',
     priority: '0.8',
   }))
 
-  const staticEntries = staticPages.map((path) => ({
-    path,
-    lastmod: new Date().toISOString(),
-    changefreq: path === '/' ? 'weekly' : 'monthly',
-    priority: path === '/' ? '1.0' : '0.7',
-  }))
-
-  const urls = [...staticEntries, ...dynamicPages]
+  const urls = [...staticPages, ...dynamicPages]
 
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urls
-  .map(
-    ({ path, lastmod, changefreq, priority }) => `  <url>
-    <loc>${siteUrl}${path}</loc>
-    <lastmod>${lastmod}</lastmod>
-    <changefreq>${changefreq}</changefreq>
-    <priority>${priority}</priority>
-  </url>`
-  )
-  .join('\n')}
+${urls.map(renderUrl).join('\n')}
 </urlset>`
 
   return new NextResponse(sitemap, {
     headers: {
       'Content-Type': 'application/xml',
+      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
     },
   })
 }

--- a/src/app/technology/page.jsx
+++ b/src/app/technology/page.jsx
@@ -1,6 +1,7 @@
 import { Card } from '@/components/Card'
 import { Section } from '@/components/Section'
 import { SimpleLayout } from '@/components/SimpleLayout'
+import { pageMetadata } from '@/lib/site'
 
 function ToolsSection({ children, ...props }) {
   return (
@@ -23,10 +24,12 @@ function Tool({ title, href, children }) {
   )
 }
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: 'Technology',
-  description: 'Software I use, gadgets I love, and other things I recommend.',
-}
+  description:
+    'Software, development tools, gadgets, marketing products, and productivity apps Michael Mitrakos uses and recommends.',
+  path: '/technology',
+})
 
 export default function Technology() {
   return (
@@ -37,7 +40,9 @@ export default function Technology() {
       <div className="space-y-20">
         <ToolsSection title="Workstation">
           <Tool title="M2 MacBook Air, 64GB RAM (2022)">
-            This machine has been a game-changer for me, offering silent performance even under demanding tasks. The efficiency and power of the M2 chip make it ideal for all my productivity needs.
+            This machine has been a game-changer for me, offering silent
+            performance even under demanding tasks. The efficiency and power of
+            the M2 chip make it ideal for all my productivity needs.
           </Tool>
           <Tool title="Apple Magic Trackpad">
             Something about all the gestures makes me feel like a wizard with
@@ -47,7 +52,10 @@ export default function Technology() {
         </ToolsSection>
         <ToolsSection title="Development tools">
           <Tool title="Visual Studio Code">
-            My coding environment of choice, Visual Studio Code provides all the features of an IDE with the flexibility of a text editor. Its extensive plugin ecosystem allows me to customize my development environment perfectly to my needs.
+            My coding environment of choice, Visual Studio Code provides all the
+            features of an IDE with the flexibility of a text editor. Its
+            extensive plugin ecosystem allows me to customize my development
+            environment perfectly to my needs.
           </Tool>
           <Tool title="iTerm2">
             I’m honestly not even sure what features I get with this that aren’t
@@ -56,27 +64,43 @@ export default function Technology() {
         </ToolsSection>
         <ToolsSection title="Marketing">
           <Tool title="Buffer">
-            Managing social media has never been easier with Buffer. It allows me to schedule posts across platforms, ensuring my content strategy is consistent without constant manual input.
+            Managing social media has never been easier with Buffer. It allows
+            me to schedule posts across platforms, ensuring my content strategy
+            is consistent without constant manual input.
           </Tool>
           <Tool title="Ubersuggest">
-            For quick keyword research and SEO insights, UberSuggest is my go-to tool. It helps me understand what my audience is searching for, optimizing my content for better visibility.
+            For quick keyword research and SEO insights, UberSuggest is my go-to
+            tool. It helps me understand what my audience is searching for,
+            optimizing my content for better visibility.
           </Tool>
           <Tool title="Google Search Console">
-            This tool is essential for monitoring and maintaining my site's presence in Google Search results. It gives me detailed reports on search traffic, crawl errors, and site security issues.
+            This tool is essential for monitoring and maintaining my site's
+            presence in Google Search results. It gives me detailed reports on
+            search traffic, crawl errors, and site security issues.
           </Tool>
         </ToolsSection>
         <ToolsSection title="Productivity">
           <Tool title="Notion">
-            I've found Notion to be incredibly versatile for organizing my thoughts, projects, and daily tasks. It's like having a digital workspace where everything from notes to project management can be seamlessly integrated.
+            I've found Notion to be incredibly versatile for organizing my
+            thoughts, projects, and daily tasks. It's like having a digital
+            workspace where everything from notes to project management can be
+            seamlessly integrated.
           </Tool>
           <Tool title="Google Drive">
-            All my document storage, sharing, and collaboration happen here. Google Drive's integration with other Google services makes it a cornerstone for my digital workflow.
+            All my document storage, sharing, and collaboration happen here.
+            Google Drive's integration with other Google services makes it a
+            cornerstone for my digital workflow.
           </Tool>
           <Tool title="Pitch">
-            For presentations, Pitch has been a revelation. It's intuitive, collaborative, and the templates are professional enough to make my presentations stand out without spending hours on design.
+            For presentations, Pitch has been a revelation. It's intuitive,
+            collaborative, and the templates are professional enough to make my
+            presentations stand out without spending hours on design.
           </Tool>
           <Tool title="Canva">
-            When it comes to design, Canva simplifies everything. Whether it's social media graphics, flyers, or even simple infographics, Canva's user-friendly interface lets me create professional-looking content quickly.
+            When it comes to design, Canva simplifies everything. Whether it's
+            social media graphics, flyers, or even simple infographics, Canva's
+            user-friendly interface lets me create professional-looking content
+            quickly.
           </Tool>
         </ToolsSection>
       </div>

--- a/src/app/thank-you/page.jsx
+++ b/src/app/thank-you/page.jsx
@@ -3,6 +3,10 @@ import { SimpleLayout } from '@/components/SimpleLayout'
 export const metadata = {
   title: 'You’re subscribed',
   description: 'Thanks for subscribing to my newsletter.',
+  robots: {
+    index: false,
+    follow: true,
+  },
 }
 
 export default function ThankYou() {

--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -1,0 +1,35 @@
+export const siteUrl = (
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.mitrakos.com'
+).replace(/\/$/, '')
+
+export const siteName = 'Michael Mitrakos'
+
+export const siteDescription =
+  'I’m Michael, a full-stack senior software engineer and tech lead from the US. For the past 10 years I’ve been leading teams to build high-quality web applications.'
+
+export function absoluteUrl(path = '/') {
+  return new URL(path, siteUrl).toString()
+}
+
+export function pageMetadata({ title, description, path, type = 'website' }) {
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: path,
+    },
+    openGraph: {
+      type,
+      url: absoluteUrl(path),
+      title,
+      description,
+      siteName,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      creator: '@Mike_Mitrakos',
+    },
+  }
+}


### PR DESCRIPTION
### Motivation

- Centralize site-wide metadata and URL helpers to ensure consistent titles, descriptions, and canonical links across pages.
- Improve SEO and discovery by making sitemap generation, RSS feed, and robots/llms endpoints use a single source of truth and emit safer XML/headers.

### Description

- Add `src/lib/site.js` which exports `siteUrl`, `siteName`, `siteDescription`, `absoluteUrl`, and `pageMetadata` helper used to build consistent metadata and URLs.
- Replace inline metadata in multiple pages (`about`, `articles`, `ebook`, `initjs`, `projects`, `technology`, etc.) with calls to `pageMetadata` and import site constants where appropriate.
- Update feed generation at `src/app/feed.xml/route.js` to use `siteDescription` and `siteUrl` from the new lib and keep author/feed setup consistent.
- Rewrite sitemap generation at `src/app/sitemap.xml/route.js` to use a structured `staticPages` list, add XML escaping helpers, render tags consistently, and include a `Cache-Control` header for caching.
- Update `src/app/robots.js` to compute a proper `host` from `siteUrl` and switch `llms.txt` to import `siteUrl` from the new lib so links remain consistent.
- Set `robots` metadata for the `thank-you` page to `index: false`, and make small content/formatting refinements in components/pages for consistency.

### Testing

- Built the site successfully with `next build` with the updated metadata and route handlers.
- Ran linting via `npm run lint` with no new lint errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a057745842c8331bf469d32ec90b5be)